### PR TITLE
Set up audience interaction/powerup framework and code a few examples

### DIFF
--- a/chariot-core/src/lib.rs
+++ b/chariot-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod entity_location;
 pub mod networking;
+pub mod physics_changes;
 pub mod player_inputs;
 mod settings;
 

--- a/chariot-core/src/physics_changes.rs
+++ b/chariot-core/src/physics_changes.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 
+#[derive(Clone)]
 pub enum PhysicsChangeType {
     NoTurningRight,
     IAmSpeed,
@@ -7,6 +8,7 @@ pub enum PhysicsChangeType {
     InSpainButTheAIsSilent,
 }
 
+#[derive(Clone)]
 pub struct PhysicsChange {
     pub change_type: PhysicsChangeType,
     pub expiration_time: Instant,

--- a/chariot-core/src/physics_changes.rs
+++ b/chariot-core/src/physics_changes.rs
@@ -9,6 +9,5 @@ pub enum PhysicsChangeType {
 
 pub struct PhysicsChange {
     pub change_type: PhysicsChangeType,
-    pub which_player: i8,
     pub expiration_time: Instant,
 }

--- a/chariot-core/src/physics_changes.rs
+++ b/chariot-core/src/physics_changes.rs
@@ -1,0 +1,14 @@
+use std::time::Instant;
+
+pub enum PhysicsChangeType {
+    NoTurningRight,
+    IAmSpeed,
+    ShoppingCart,
+    InSpainButTheAIsSilent,
+}
+
+pub struct PhysicsChange {
+    pub change_type: PhysicsChangeType,
+    pub which_player: i8,
+    pub expiration_time: Instant,
+}

--- a/chariot-server/src/game.rs
+++ b/chariot-server/src/game.rs
@@ -101,7 +101,7 @@ impl GameServer {
         for player in &mut self.game_state.players {
             player
                 .physics_changes
-                .retain(|change| change.expiration_time.duration_since(now).is_zero());
+                .retain(|change| !change.expiration_time.duration_since(now).is_zero());
             player.set_bounding_box_dimensions();
         }
 

--- a/chariot-server/src/game.rs
+++ b/chariot-server/src/game.rs
@@ -95,7 +95,13 @@ impl GameServer {
     fn simulate_game(&mut self) {
         let mut new_players = vec![];
 
+        let now = Instant::now();
+
+        // earlier_time.duration_since(later_time) will return 0; filter out those for which the expiration time is earlier than the current time
         for player in &mut self.game_state.players {
+            player
+                .physics_changes
+                .retain(|change| change.expiration_time.duration_since(now).is_zero());
             player.set_bounding_box_dimensions();
         }
 

--- a/chariot-server/src/physics/collisions.rs
+++ b/chariot-server/src/physics/collisions.rs
@@ -117,6 +117,7 @@ impl PlayerEntity {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use chariot_core::{
         entity_location::EntityLocation,
@@ -144,6 +145,7 @@ mod tests {
 
             size: DVec3::new(10.0, 10.0, 10.0),
             bounding_box: [[-5.0, 5.0], [-5.0, 5.0], [-5.0, 5.0]],
+            physics_changes: Vec::new(),
         };
     }
 

--- a/chariot-server/src/physics/mod.rs
+++ b/chariot-server/src/physics/mod.rs
@@ -55,7 +55,7 @@ impl PlayerEntity {
             mass: self.mass,
             size: self.size,
             bounding_box: self.bounding_box,
-            physics_changes: Vec::new(),
+            physics_changes: self.physics_changes.clone(),
         };
 
         new_player.apply_physics_changes();

--- a/chariot-server/src/physics/mod.rs
+++ b/chariot-server/src/physics/mod.rs
@@ -1,3 +1,4 @@
+use chariot_core::physics_changes::PhysicsChangeType;
 use glam::DVec3;
 
 use chariot_core::entity_location::EntityLocation;
@@ -38,7 +39,7 @@ impl PlayerEntity {
             delta_velocity += self.delta_v_from_collision_with_player(collider);
         }
 
-        return PlayerEntity {
+        let mut new_player = PlayerEntity {
             player_inputs: PlayerInputs {
                 engine_status: self.player_inputs.engine_status,
                 rotation_status: self.player_inputs.rotation_status,
@@ -54,7 +55,12 @@ impl PlayerEntity {
             mass: self.mass,
             size: self.size,
             bounding_box: self.bounding_box,
+            physics_changes: Vec::new(),
         };
+
+        new_player.apply_physics_changes();
+
+        return new_player;
     }
 
     fn sum_of_self_forces(&self) -> DVec3 {
@@ -115,8 +121,45 @@ impl PlayerEntity {
     fn rolling_resistance_force_on_object(&self) -> DVec3 {
         return self.velocity * self.mass * -1.0 * GLOBAL_CONFIG.rolling_resistance_coefficient;
     }
+
+    fn apply_physics_changes(&mut self) {
+        for change in &self.physics_changes {
+            match change.change_type {
+                PhysicsChangeType::IAmSpeed => {
+                    let flat_speed_increase = 30.0;
+                    self.velocity = self.velocity * (self.velocity.length() + flat_speed_increase);
+                }
+                PhysicsChangeType::NoTurningRight => {
+                    if matches!(
+                        self.player_inputs.rotation_status,
+                        RotationStatus::InSpinClockwise
+                    ) {
+                        self.player_inputs.rotation_status = RotationStatus::NotInSpin;
+                        self.angular_velocity -= GLOBAL_CONFIG.car_spin;
+                    }
+                }
+                PhysicsChangeType::ShoppingCart => {
+                    self.angular_velocity += GLOBAL_CONFIG.car_spin / 2.0;
+                }
+                PhysicsChangeType::InSpainButTheAIsSilent => {
+                    match self.player_inputs.rotation_status {
+                        RotationStatus::InSpinClockwise => {}
+                        RotationStatus::NotInSpin => {
+                            self.player_inputs.rotation_status = RotationStatus::InSpinClockwise;
+                            self.angular_velocity += GLOBAL_CONFIG.car_spin;
+                        }
+                        RotationStatus::InSpinCounterclockwise => {
+                            self.player_inputs.rotation_status = RotationStatus::InSpinClockwise;
+                            self.angular_velocity += 2.0 * GLOBAL_CONFIG.car_spin;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
+#[cfg(test)]
 mod tests {
     use glam::DVec3;
 
@@ -147,6 +190,7 @@ mod tests {
 
             size: DVec3::new(10.0, 10.0, 10.0),
             bounding_box: [[-5.0, 5.0], [-5.0, 5.0], [-5.0, 5.0]],
+            physics_changes: Vec::new(),
         };
 
         props = props.do_physics_step(1.0, Vec::new());
@@ -185,6 +229,7 @@ mod tests {
 
             size: DVec3::new(10.0, 10.0, 10.0),
             bounding_box: [[15.0, 25.0], [25.0, 35.0], [35.0, 45.0]],
+            physics_changes: Vec::new(),
         };
 
         props = props.do_physics_step(1.0, Vec::new());
@@ -220,6 +265,7 @@ mod tests {
 
             size: DVec3::new(10.0, 10.0, 10.0),
             bounding_box: [[15.0, 25.0], [25.0, 35.0], [35.0, 45.0]],
+            physics_changes: Vec::new(),
         };
 
         props = props.do_physics_step(1.0, Vec::new());
@@ -259,6 +305,7 @@ mod tests {
 
             size: DVec3::new(10.0, 10.0, 10.0),
             bounding_box: [[15.0, 25.0], [25.0, 35.0], [35.0, 45.0]],
+            physics_changes: Vec::new(),
         };
 
         props = props.do_physics_step(1.0, Vec::new());

--- a/chariot-server/src/physics/player_entity.rs
+++ b/chariot-server/src/physics/player_entity.rs
@@ -1,4 +1,5 @@
 use chariot_core::entity_location::EntityLocation;
+use chariot_core::physics_changes::PhysicsChange;
 use chariot_core::player_inputs::PlayerInputs;
 use glam::DVec3;
 
@@ -14,4 +15,6 @@ pub struct PlayerEntity {
 
     pub player_inputs: PlayerInputs,
     pub entity_location: EntityLocation,
+
+    pub physics_changes: Vec<PhysicsChange>,
 }


### PR DESCRIPTION
Set up a framework for server code for "physics changes" (audience interactions and powerups that could modify physics). Types of physics changes are defined in core - client will want to refer to them for e.g. graphical effects applying to certain effects 

Also codes a few of the more well-defined/easier examples [from Notion](https://www.notion.so/chairiots/Game-Design-85dc4f8e1fd044db81e25ec99673e748). The flow to add a new physics change effect after these is simple:
1. Add a value in `PhysicsChangeType` within `chariot_core/physics_changes.rs`
2. Add handling for the new enum value in `apply_physics_changes` within `chariot_server/physics/mod.rs`
3. To use the new effect, just add to the `physics_changes` vector within a `PlayerEntity` and the effect will apply on the next physics tick (Important note: effects apply after usual physics logic, so in some circumstances you may have to undo some physics)

Review welcome - shouldn't be large or difficult to review