### PR TITLE
Physics fixes

### DIFF
--- a/chariot-client/src/graphics.rs
+++ b/chariot-client/src/graphics.rs
@@ -198,7 +198,7 @@ impl GraphicsManager {
         *player_transform = Transform::from_entity_location(&location);
 
         // if this player is the main player, update the camera too (based on velocity)
-        if player_entity == self.camera_entity {
+        if player_entity == self.camera_entity && *velocity != DVec3::ZERO {
             if let Some(camera) = self.world.get_mut::<Camera>(self.camera_entity) {
                 // first we have to compensate for the rotation of the chair model
                 let rotation_angle = location.unit_steer_direction.angle_between(DVec3::X);

--- a/chariot-server/src/physics/player_entity.rs
+++ b/chariot-server/src/physics/player_entity.rs
@@ -100,7 +100,8 @@ impl PlayerEntity {
         let term2 = (v1 - v2).dot(x1 - x2) / (x1 - x2).length_squared();
         let term3 = x1 - x2;
 
-        return term1 * term2 * term3;
+        let result = term1 * term2 * term3;
+        return DVec3::new(result.x, 0.0, result.z);
     }
 
     /* Given a set of physical properties, compute and return what next tick's

--- a/chariot-server/src/physics/player_entity.rs
+++ b/chariot-server/src/physics/player_entity.rs
@@ -148,6 +148,8 @@ impl PlayerEntity {
         let mut new_velocity = self.velocity + delta_velocity;
         if new_velocity.length() > GLOBAL_CONFIG.max_car_speed {
             new_velocity = new_velocity.normalize() * GLOBAL_CONFIG.max_car_speed;
+        } else if new_velocity.length() < 0.05 {
+            new_velocity = DVec3::ZERO;
         }
 
         let mut new_player = PlayerEntity {
@@ -227,10 +229,14 @@ impl PlayerEntity {
             // divide velocity by its magnitude to have a unit vector pointing
             // towards current heading, then apply the force in the reverse direction
             EngineStatus::Braking => {
-                return self.velocity / self.velocity.length()
-                    * -1.0
-                    * self.mass
-                    * GLOBAL_CONFIG.car_brake;
+                return if self.velocity == DVec3::ZERO {
+                    DVec3::ZERO
+                } else {
+                    self.velocity / self.velocity.length()
+                        * -1.0
+                        * self.mass
+                        * GLOBAL_CONFIG.car_brake
+                };
             }
             // And there is no player-applied force when not accelerating or braking
             EngineStatus::Neutral => return DVec3::new(0.0, 0.0, 0.0),

--- a/chariot-server/src/physics/player_entity.rs
+++ b/chariot-server/src/physics/player_entity.rs
@@ -226,17 +226,13 @@ impl PlayerEntity {
                     * self.mass
                     * GLOBAL_CONFIG.car_accelerator;
             }
-            // divide velocity by its magnitude to have a unit vector pointing
-            // towards current heading, then apply the force in the reverse direction
+            // apply the force in the reverse direction of current velocity;
+            // just do nothing if velocity is zero
             EngineStatus::Braking => {
-                return if self.velocity == DVec3::ZERO {
-                    DVec3::ZERO
-                } else {
-                    self.velocity / self.velocity.length()
-                        * -1.0
-                        * self.mass
-                        * GLOBAL_CONFIG.car_brake
-                };
+                return self.velocity.normalize_or_zero()
+                    * -1.0
+                    * self.mass
+                    * GLOBAL_CONFIG.car_brake;
             }
             // And there is no player-applied force when not accelerating or braking
             EngineStatus::Neutral => return DVec3::new(0.0, 0.0, 0.0),

--- a/chariot-server/src/physics/player_entity.rs
+++ b/chariot-server/src/physics/player_entity.rs
@@ -96,7 +96,7 @@ impl PlayerEntity {
         let x1 = self.entity_location.position;
         let x2 = other.entity_location.position;
 
-        let term1 = (-2.0 * m2) / (m1 + m2);
+        let term1 = (2.0 * m2) / (m1 + m2);
         let term2 = (v1 - v2).dot(x1 - x2) / (x1 - x2).length_squared();
         let term3 = x1 - x2;
 


### PR DESCRIPTION
Fixes three physics issues (one commit per issue) for better QoL:

- Colliding chairs kinda jittered together / didn't leave room for Jesus before separating when colliding: this turns out to be because the collision force was facing the wrong direction, so weird things happened
- Occasionally, collisions (especially when 3 chairs were involved) added a vertical component, so chairs went above or below the plane of the track
- The camera was very flickery / changed directions unexpectedly when velocity was very low; the solution here consisted of zeroing out velocity when under a certain threshold so that the camera direction wouldn't change in response to very small velocities, not changing the camera angle at all when the client is given a velocity of zero (necessary since otherwise the camera resets its angle to not depend on velocity), and adding an edge case to not break everything when braking if velocity is zero

All of this was tested live and looks good - in particular, collisions (with Aidan from Group 4, shout out) seem not unreasonable, but acceleration is fast enough that it's not very impactful to actually collide with another player.