### PR TITLE
added simple ui drawable

### DIFF
--- a/chariot-client/Cargo.toml
+++ b/chariot-client/Cargo.toml
@@ -14,3 +14,4 @@ pollster = "0.2.5"
 bytemuck = { version = "1.4", features = ["derive"] }
 glam = "0.20.3"
 gltf = "1.0.0"
+image = "0.24.2"

--- a/chariot-client/shaders/ui.wgsl
+++ b/chariot-client/shaders/ui.wgsl
@@ -1,0 +1,27 @@
+
+struct VertexOutput {
+	[[builtin(position)]] position : vec4<f32>;
+	[[location(1)]] tex_coords : vec2<f32>;
+};
+
+[[stage(vertex)]]
+fn vs_main([[location(0)]] position: vec2<f32>, [[location(1)]] tex_coords: vec2<f32>) -> VertexOutput {
+	var out : VertexOutput;
+	out.position =  vec4<f32>(position, 0.0, 1.0);
+	out.tex_coords = tex_coords;
+    return out;
+}
+
+[[group(0), binding(0)]]
+var texture: texture_2d<f32>;
+
+[[stage(fragment)]]
+fn fs_main(in: VertexOutput) -> [[location(0)]] vec4<f32> {
+	let diffuse_size = textureDimensions(texture);
+	let diffuse_sizef = vec2<f32>(diffuse_size);
+	let tc = vec2<i32>(in.tex_coords * diffuse_sizef);
+
+	let color = textureLoad(texture, tc, 0);
+
+	return color;
+}

--- a/chariot-client/src/drawable/mod.rs
+++ b/chariot-client/src/drawable/mod.rs
@@ -32,18 +32,6 @@ impl StaticMeshDrawable {
         submesh_idx: usize,
     ) -> Self {
         let shadow_pass = "shadow";
-        /*let shadow_draws = lights
-        .iter()
-        .map(|l| {
-            ShadowDrawTechnique::new(
-                renderer,
-                static_mesh,
-                submesh_idx,
-                shadow_pass,
-                l.framebuffer_name.as_str(),
-            )
-        })
-        .collect();*/
 
         let shadow_draws = vec![ShadowDrawTechnique::new(
             renderer,
@@ -104,6 +92,26 @@ impl Drawable for StaticMeshDrawable {
 
         let forward_item = self.forward_draw.render_item(resources);
         builder.add(forward_item, &shadow_deps);
+
+        builder.build()
+    }
+}
+
+pub struct UIDrawable {
+    pub layers: Vec<UILayerTechnique>,
+}
+
+impl Drawable for UIDrawable {
+    fn render_graph<'a>(&'a self, resources: &'a ResourceManager) -> render_job::RenderGraph<'a> {
+        let mut builder = render_job::RenderGraphBuilder::new();
+
+        if !self.layers.is_empty() {
+            let mut last_dep =
+                builder.add_root(self.layers.first().unwrap().render_item(resources));
+            for layer in self.layers.iter().skip(1) {
+                last_dep = builder.add(layer.render_item(resources), &[last_dep]);
+            }
+        }
 
         builder.build()
     }

--- a/chariot-client/src/graphics.rs
+++ b/chariot-client/src/graphics.rs
@@ -25,7 +25,12 @@ pub fn register_passes(renderer: &mut Renderer) {
 
     renderer.register_pass(
         "postprocess",
-        &util::direct_graphics_depth_pass!("shaders/postprocess.wgsl"),
+        &util::direct_graphics_nodepth_pass!("shaders/postprocess.wgsl"),
+    );
+
+    renderer.register_pass(
+        "ui",
+        &util::direct_graphics_nodepth_pass!("shaders/ui.wgsl"),
     );
 }
 
@@ -92,6 +97,7 @@ pub struct GraphicsManager {
     pub renderer: Renderer,
     pub resources: ResourceManager,
 
+    test_ui: UIDrawable,
     postprocess: technique::FSQTechnique,
     player_entities: [Option<Entity>; 4],
     camera_entity: Entity,
@@ -129,6 +135,19 @@ impl GraphicsManager {
             renderer.register_framebuffer("shadow_out1", fb_desc);
         }
 
+        let text_handle = resources.import_texture(&renderer, "text.png");
+        let text_tex = resources.textures.get(&text_handle).unwrap();
+        let test_ui = UIDrawable {
+            layers: vec![technique::UILayerTechnique::new(
+                &renderer,
+                glam::vec2(0.0, 0.0),
+                glam::vec2(0.2, 0.2),
+                glam::vec2(0.0, 0.0),
+                glam::vec2(1.0, 1.0),
+                &text_tex,
+            )],
+        };
+
         let postprocess = technique::FSQTechnique::new(&renderer, &resources, "postprocess");
 
         let (world, chair) = setup_world(&mut resources, &mut renderer);
@@ -137,6 +156,7 @@ impl GraphicsManager {
             world: world,
             renderer: renderer,
             resources: resources,
+            test_ui: test_ui,
             postprocess: postprocess,
             player_entities: [Some(chair), None, None, None],
             camera_entity: NULL_ENTITY,
@@ -339,6 +359,9 @@ impl GraphicsManager {
         );
         let postprocess_graph = self.postprocess.render_item(&self.resources).to_graph();
         render_job.merge_graph_after("forward", postprocess_graph);
+
+        let ui_graph = self.test_ui.render_graph(&self.resources);
+        render_job.merge_graph_after("postprocess", ui_graph);
 
         self.renderer.render(&render_job);
     }

--- a/chariot-client/src/renderer/mod.rs
+++ b/chariot-client/src/renderer/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     borrow::Cow,
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::atomic::{AtomicUsize, Ordering},
 };
 
@@ -202,7 +202,12 @@ impl Renderer {
                             push_constant_ranges: push_constant_ranges,
                         });
 
-                let surface_target: &[wgpu::ColorTargetState] = &[self.surface_format.into()];
+                let surface_color_state = wgpu::ColorTargetState {
+                    format: self.surface_format,
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    write_mask: wgpu::ColorWrites::ALL,
+                };
+                let surface_target: &[wgpu::ColorTargetState] = &[surface_color_state];
                 let target_formats = targets.unwrap_or(surface_target);
 
                 let render_pipeline =
@@ -385,6 +390,7 @@ impl Renderer {
         framebuffer_name: &str,
         framebuffers: &'a HashMap<String, FramebufferDescriptor>,
         encoder: &'a mut wgpu::CommandEncoder,
+        force_no_clear: bool,
     ) -> wgpu::RenderPass<'a> {
         let framebuffer_desc = framebuffers
             .get(&String::from(framebuffer_name))
@@ -397,7 +403,11 @@ impl Renderer {
                 resolve_target: None,
                 ops: wgpu::Operations {
                     load: if let Some(color) = framebuffer_desc.clear_color {
-                        wgpu::LoadOp::Clear(color)
+                        if force_no_clear {
+                            wgpu::LoadOp::Load
+                        } else {
+                            wgpu::LoadOp::Clear(color)
+                        }
                     } else {
                         wgpu::LoadOp::Load
                     },
@@ -487,19 +497,32 @@ impl Renderer {
 
         // kind of sketch to re-set this every frame
         {
-            let view = frame
+            /*let surface_view = frame
                 .texture
                 .create_view(&wgpu::TextureViewDescriptor::default());
             self.framebuffers.insert(
                 String::from("surface"),
                 FramebufferDescriptor {
-                    color_attachments: vec![view],
+                    color_attachments: vec![surface_view],
                     depth_stencil_attachment: Some(
                         self.depth_texture
                             .create_view(&wgpu::TextureViewDescriptor::default()),
                     ),
                     clear_color: Some(wgpu::Color::BLACK),
                     clear_depth: true,
+                },
+            );*/
+
+            let surface_nodepth_view = frame
+                .texture
+                .create_view(&wgpu::TextureViewDescriptor::default());
+            self.framebuffers.insert(
+                String::from("surface_nodepth"),
+                FramebufferDescriptor {
+                    color_attachments: vec![surface_nodepth_view],
+                    depth_stencil_attachment: None,
+                    clear_color: Some(wgpu::Color::BLACK),
+                    clear_depth: false,
                 },
             );
         }
@@ -508,6 +531,7 @@ impl Renderer {
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
 
+        let mut cleared_framebuffers = HashSet::<&str>::new();
         let mut job_iter = render_job.iter_bfs().peekable();
         while job_iter.peek().is_some() {
             let (pass_name, items) = job_iter.next().unwrap();
@@ -522,8 +546,13 @@ impl Renderer {
                     render_pipeline: _,
                 } => {
                     let fb_name = render_item_framebuffer_name(&items[0]).unwrap();
-                    let mut wgpu_rpass =
-                        Renderer::new_wgpu_render_pass(fb_name, &self.framebuffers, &mut encoder);
+                    let force_no_clear = cleared_framebuffers.contains(fb_name);
+                    let mut wgpu_rpass = Renderer::new_wgpu_render_pass(
+                        fb_name,
+                        &self.framebuffers,
+                        &mut encoder,
+                        force_no_clear,
+                    );
                     Renderer::encode_graphics_pass(&mut wgpu_rpass, pass_name, &self.passes, items);
                     while Renderer::is_same_framebuffer(job_iter.peek(), fb_name) {
                         let (pass_name, items) = job_iter.next().unwrap();
@@ -534,6 +563,8 @@ impl Renderer {
                             items,
                         );
                     }
+
+                    cleared_framebuffers.insert(fb_name);
                 }
                 _ => (),
             }

--- a/chariot-client/src/resources/mod.rs
+++ b/chariot-client/src/resources/mod.rs
@@ -486,4 +486,26 @@ impl ResourceManager {
         let handle = self.framebuffers.get(&name.to_string())?.get(index)?;
         self.textures.get(&handle)
     }
+
+    pub fn import_texture(&mut self, renderer: &Renderer, filename: &str) -> TextureHandle {
+        let tex_name = filename.split(".").next().expect("invalid filename format");
+        let resource_path = format!("{}/{}", GLOBAL_CONFIG.resource_folder, filename);
+        let img = image::open(resource_path).unwrap();
+        let img_rgba8 = img.into_rgba8();
+
+        let texture = renderer.create_texture2D_init(
+            tex_name,
+            winit::dpi::PhysicalSize::<u32> {
+                width: img_rgba8.width(),
+                height: img_rgba8.height(),
+            },
+            wgpu::TextureFormat::Rgba8Unorm,
+            wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::STORAGE_BINDING,
+            &img_rgba8.into_raw(),
+        );
+
+        let handle = TextureHandle::unique();
+        self.textures.insert(handle, texture);
+        return handle;
+    }
 }


### PR DESCRIPTION
+ some fixes to framebuffers without depth
Usage to create is: 
```rust
let text_handle = resources.import_texture(&renderer, "text.png");
let text_tex = resources.textures.get(&text_handle).unwrap();
let test_ui = UIDrawable {
    // layers specifies a list of draws that will be done in order to get proper foreground/backround
    layers: vec![technique::UILayerTechnique::new(
        &renderer,
        glam::vec2(0.0, 0.0), // pos on screen (0,0 is upper left)
        glam::vec2(0.2, 0.2), // size on screen (normalized where 1, 1 is size of entire screen)
        glam::vec2(0.0, 0.0), // texture coord pos (normalized)
        glam::vec2(1.0, 1.0), // texture coord size, (normalized, where 1,1 is entire texture)
        &text_tex,
    )],
};
```
Then the draw graph is merged after postprocessing in `render()`.
A little awkward with all the options but it should be able to handle a good range of things.