### PR TITLE
Network Resilience

### DIFF
--- a/chariot-client/src/graphics.rs
+++ b/chariot-client/src/graphics.rs
@@ -147,7 +147,7 @@ impl GraphicsManager {
 
         let mut test_string = StringDrawable::new("ArialMT", 18.0);
         test_string.set(
-            "chariot - 0.6.9",
+            "chariot - 0.6.11",
             Vec2::new(0.005, 0.027),
             &renderer,
             &mut resources,


### PR DESCRIPTION
Two parts to this PR:

- [ ] on the client, if we disconnect from the server, rather than panic, keep attempting connections with exponential backoff and only panic if we can't connect for a full 30 seconds. If the reconnect is successful, pick up the game where we left off
- [ ] on the server, if a client disconnects, freeze the game loop until they have reconnected. If they do not reconnect after 30 seconds, die