### PR TITLE
Fix bug where you couldn't get ramped while going fast

### DIFF
--- a/chariot-server/src/physics/bounding_box.rs
+++ b/chariot-server/src/physics/bounding_box.rs
@@ -110,13 +110,13 @@ impl BoundingBox {
         let (mut x_dist, mut y_dist, mut z_dist) = (0.0, 0.0, 0.0);
         for rotated_corner in corners_coordinates {
             if rotated_corner.x.abs() > x_dist as f32 {
-                x_dist = f64::from(rotated_corner.x);
+                x_dist = f64::from(rotated_corner.x.abs());
             }
             if rotated_corner.y.abs() > y_dist as f32 {
-                y_dist = f64::from(rotated_corner.y);
+                y_dist = f64::from(rotated_corner.y.abs());
             }
             if rotated_corner.z.abs() > z_dist as f32 {
-                z_dist = f64::from(rotated_corner.z);
+                z_dist = f64::from(rotated_corner.z.abs());
             }
         }
 

--- a/chariot-server/src/physics/ramp.rs
+++ b/chariot-server/src/physics/ramp.rs
@@ -134,7 +134,7 @@ impl PlayerEntity {
         // the ramp, or in the strip leading out from the ramp face
         if x >= ramp_min_x && x <= ramp_max_x && z >= ramp_min_z && z <= ramp_max_z {
             return ramp.get_height_at_coordinates(x, z) - (self.entity_location.position.y - 1.0)
-                < 1.0;
+                < 1.5;
         }
 
         // to enter the ramp, you must be within the strip leading out from the


### PR DESCRIPTION
As per title and commit (bug was that you'd collide off of ramps if you were going too fast when running into them, even from the correct side)