### PR TITLE
Go faster when on the track!

### DIFF
--- a/chariot-core/src/settings.rs
+++ b/chariot-core/src/settings.rs
@@ -35,6 +35,8 @@ pub struct Settings {
     pub wall_bounciness: f64,
     pub player_bounciness: f64,
 
+    pub off_track_speed_penalty: f64,
+
     // Voting
     pub audience_vote_time_ms: u64,
 }
@@ -87,6 +89,8 @@ impl Settings {
             .set_default("wall_bounciness", 3.0)?
             // How hard we should bounce off other players (1.0 = real-world physically accurate)
             .set_default("player_bounciness", 3.0)?
+            // How much slower should you go when off-track? (0.20 => 80% of on-track speed when off)
+            .set_default("off_track_speed_penalty", 0.20)?
             .set_default("audience_vote_time_ms", 30000)?
             .add_source(File::with_name("config.yaml").required(false))
             .build()?;

--- a/chariot-server/src/game/map.rs
+++ b/chariot-server/src/game/map.rs
@@ -16,6 +16,9 @@ pub struct Map {
     pub colliders: Vec<BoundingBox>,
     pub ramps: Vec<Ramp>,
 
+    // basically: while you're on the track, you should get a speedup (vroom vroom zoom zoom)
+    pub speedup_zones: Vec<BoundingBox>,
+
     // Map's checkpoints, which track progress through the track
     pub checkpoints: Vec<Checkpoint>,
 
@@ -84,6 +87,8 @@ impl Map {
 
         let mut colliders: Vec<BoundingBox> = Vec::new();
         let mut ramps: Vec<Ramp> = Vec::new();
+
+        let mut speedup_zones: Vec<BoundingBox> = Vec::new();
 
         let mut checkpoints: Vec<Checkpoint> = Vec::new();
         let mut major_zones: Vec<Zone> = Vec::new();
@@ -202,6 +207,8 @@ impl Map {
                                     incline_direction: incline_direction_vec,
                                 };
                                 ramps.push(ramp);
+                            } else if purpose == "speedup" {
+                                speedup_zones.push(mesh_bounds);
                             } else {
                                 // panic!(
                                 //     "Mesh '{}' has unknown purpose '{}'!",
@@ -226,6 +233,7 @@ impl Map {
         core::result::Result::Ok(Self {
             colliders,
             ramps,
+            speedup_zones,
             checkpoints,
             major_zones,
             finish_line: finish_line

--- a/chariot-server/src/game/mod.rs
+++ b/chariot-server/src/game/mod.rs
@@ -438,6 +438,14 @@ impl GameServer {
                     .colliders
                     .clone();
 
+                let speedup_zones = &self
+                    .game_state
+                    .map
+                    .as_ref()
+                    .expect("No map loaded in game loop!")
+                    .speedup_zones
+                    .clone();
+
                 self.game_state.players = [0, 1, 2, 3].map(|n| {
                     self.game_state.players[n].do_physics_step(
                         1.0,
@@ -448,6 +456,7 @@ impl GameServer {
                             .as_mut()
                             .expect("No map loaded in game loop!")
                             .trigger_iter(),
+                        speedup_zones,
                         per_player_current_ramps.get(n).unwrap(),
                     )
                 });

--- a/chariot-server/src/physics/player_entity.rs
+++ b/chariot-server/src/physics/player_entity.rs
@@ -7,6 +7,7 @@ use chariot_core::player::{
     player_inputs::{EngineStatus, PlayerInputs, RotationStatus},
 };
 use chariot_core::sound_effect::SoundEffect;
+use chariot_core::GLOBAL_CONFIG;
 use glam::{DMat3, DVec3};
 
 use crate::physics::trigger_entity::TriggerEntity;
@@ -115,6 +116,7 @@ impl PlayerEntity {
         potential_colliders: Vec<&PlayerEntity>,
         potential_terrain: Vec<BoundingBox>,
         potential_triggers: impl Iterator<Item = &'a mut dyn TriggerEntity>,
+        speedup_zones: &Vec<BoundingBox>,
         ramp_collision_result: &RampCollisionResult,
     ) -> PlayerEntity {
         let mut has_collided_with_players = false;
@@ -215,6 +217,14 @@ impl PlayerEntity {
                     }
                 }
             }
+        }
+
+        // If not in contact with any speedup zones (= in the air or off-track), apply a speed penalty
+        if speedup_zones
+            .iter()
+            .all(|zone| !zone.is_colliding(&self.bounding_box))
+        {
+            new_velocity *= (1.0 - GLOBAL_CONFIG.off_track_speed_penalty);
         }
 
         let new_steer_direction =

--- a/chariot-server/src/physics/tests.rs
+++ b/chariot-server/src/physics/tests.rs
@@ -82,6 +82,7 @@ fn test_spinning() {
         Vec::new(),
         Vec::new(),
         std::iter::empty(),
+        &Vec::new(),
         &RampCollisionResult::NoEffect,
     );
 
@@ -93,6 +94,7 @@ fn test_spinning() {
         Vec::new(),
         Vec::new(),
         std::iter::empty(),
+        &Vec::new(),
         &RampCollisionResult::NoEffect,
     );
 


### PR DESCRIPTION
Prerequisite: recent chaired drive track download.

You go faster when on the track! = there's a 20% penalty to speed when you're off the track. Nice and simple, works perfectly, cool and fun. Come to think of it, this might be something we want to stat-ize/interaction-ize (options: go faster when you're _not_ on the track? just go really slow when you're not on the track) - but that can easily go elsewhere.

she works and she's beautiful