### PR TITLE
made voting states clear + removed unneeded renders

### DIFF
--- a/chariot-client/src/application.rs
+++ b/chariot-client/src/application.rs
@@ -270,6 +270,9 @@ impl Application {
                 ClientBoundPacket::StartNextGame => {
                     self.graphics.load_pregame();
                 }
+                ClientBoundPacket::VotingCooldown => self
+                    .graphics
+                    .maybe_set_announcement_state(AnnouncementState::None),
             }
         }
     }

--- a/chariot-core/src/networking/packets.rs
+++ b/chariot-core/src/networking/packets.rs
@@ -57,14 +57,13 @@ pub enum ClientBoundPacket {
         #[serde(with = "serde_millis")]
         time_until_vote_end: Duration,
     }, // Sent when the audience begins voting (suspense!)
-
     InteractionActivate {
         question: QuestionData,
         decision: QuestionOption,
         #[serde(with = "serde_millis")]
         time_effect_is_live: Duration,
     }, // Sent when the audience has voted on something
-
+    VotingCooldown,
     LapUpdate(LapNumber),       // What lap are you now on?
     PlacementUpdate(Placement), // What place in the race are you now at?
 

--- a/chariot-server/src/game/mod.rs
+++ b/chariot-server/src/game/mod.rs
@@ -579,8 +579,17 @@ impl GameServer {
                     } => {
                         if *decision_end_time < now {
                             // the vote has been in effect enough, lets go to the cooldown
-                            *voting_game_state =
-                                VotingState::VoteCooldown(now + Duration::new(10, 0))
+                            let time_voting_starts = now + Duration::new(5, 0);
+                            *voting_game_state = VotingState::VoteCooldown(time_voting_starts);
+                            for client in self.connections.iter_mut() {
+                                client.push_outgoing(ClientBoundPacket::VotingCooldown);
+                            }
+                            GameServer::broadcast_ws(
+                                &mut self.ws_connections,
+                                WSAudienceBoundMessage::Countdown {
+                                    time: time_voting_starts,
+                                },
+                            )
                         }
                     }
                     VotingState::VoteCooldown(cooldown) => {

--- a/chariot-web/pages/game.tsx
+++ b/chariot-web/pages/game.tsx
@@ -18,6 +18,7 @@ const Game: NextPage = () => {
 	const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
 
 	const { socket, uuid, prompt, winner, totalConnected, countdownTime, gameState, optionResults } = context;
+	const othersConnected = totalConnected - 1;
 
 	useEffect(() => {
 		if (winner !== null) {
@@ -54,16 +55,16 @@ const Game: NextPage = () => {
 	}
 
 	const timeLeft = countdownTime ? countdownTime.getSeconds() - new Date().getSeconds() : -1;
-	const timeLeftText = gameState === 'voting' ? `Voting ends in ${timeLeft}s` : `${timeLeft}s until next vote`
+	const timeLeftText = gameState === 'voting' ? `Voting ends in ${timeLeft}s` : gameState === 'winner' ? `${timeLeft}s until effects subside` : `${timeLeft}s until next vote`
 
 	return (<div className={styles.container}>
 		<div className={styles.blockText}>
 			<p>{showStandings ? "Standings" : (timeLeft >= 0) ? timeLeftText : "Waiting for Next Vote"}</p>
 		</div>
-		{!showStandings && prompt !== null &&
+		{!showStandings && prompt !== null && gameState !== 'waiting' &&
 			<div className={styles.buttonLayout}>
 				{prompt.options.map((({ label }, choice) => {
-					const labelText = `${label}${(gameState === 'winner' && optionResults?.length === prompt.options.length) ? " " + toPercentage(optionResults[choice].percentage) : ""}`
+					const labelText = `${label}${(gameState === 'winner' && optionResults?.length === prompt.options.length) ? " — " + toPercentage(optionResults[choice].percentage) : ""}`
 					return (
 						<Button width="100%" clickable={winner === null} state={choice === winner ? 'voted' : choice === selectedIdx ? 'selected' : 'unselected'} key={choice} text={labelText} onClick={() => {
 							if (winner === null) {
@@ -83,7 +84,7 @@ const Game: NextPage = () => {
 			<Button width="80%" text={showStandings ? "hide standings" : "see standings"} onClick={() => { setShowStandings(!showStandings) }} style='minimal' />
 			<div className={styles.liveAudience}>
 				<Image src={AudienceIcon} height="32.56" alt="audience icon" />
-				<p>{totalConnected} Other{totalConnected !== 1 && 's'} Online</p>
+				<p>{othersConnected} Other{othersConnected !== 1 && 's'} Online</p>
 			</div>
 		</div>
 

--- a/chariot-web/src/utils/networking.tsx
+++ b/chariot-web/src/utils/networking.tsx
@@ -61,6 +61,7 @@ export const handleSocket = (context: GlobalContextType, msg: MessageEvent) => {
 		context.setTotalConnected(message.AudienceCount);
 	} else if (message.Countdown !== undefined) {
 		context.setCountdownTime(new Date(message.Countdown.time));
+		context.setGameState('waiting');
 	} else {
 		console.log("new data type");
 		console.log(message);


### PR DESCRIPTION
This makes it so
- [x] we don't show any text during the vote cooldown state
- [x] the web ui clearly tells you what's going on
- [x] fixes all the weird time issues I was getting (they were all seemingly related to state issues around countdown time)